### PR TITLE
[Bug Fix] safe guard for implicit default data and joint type

### DIFF
--- a/mimickit/anim/kin_char_model.py
+++ b/mimickit/anim/kin_char_model.py
@@ -415,10 +415,15 @@ class KinCharModel():
         return dof_idx
 
     def _parse_default_joint_type(self, xml_node):
-        default_data = xml_node.find("default")
-        default_data = default_data.findall("default")
-
         joint_type_str = "hinge"
+
+        default_data = xml_node.find("default")
+        if (default_data is None):
+            return joint_type_str
+        
+        default_data = default_data.findall("default")
+        if (default_data is None):
+            return joint_type_str
 
         for data in default_data:
             class_data = data.attrib.get("class")


### PR DESCRIPTION
Hi Jason,

This is related to the previous xml improvement that I mentioned in the issues. 

I noticed that if an xml model file doesn't have \<default\> tag, 

```
default_data = xml_node.find("default") # this gives None
```

and `default_data = default_data.findall("default")` will result in error 

```
File "/home/xindong/Documents/projects/MimicKit/mimickit/anim/kin_char_model.py", line 419, in _parse_default_joint_type
    default_data = default_data.findall("default")
AttributeError: 'NoneType' object has no attribute 'findall'
```
The commited changes can safe guard the program to return the default_str_type, which is "hinge".

Feel free to give a suggestion and thanks for reviewing this!