### PR TITLE
[Bug Fix] get_motion() returns a undefined attribute _motions

### DIFF
--- a/mimickit/anim/motion_lib.py
+++ b/mimickit/anim/motion_lib.py
@@ -26,9 +26,6 @@ class MotionLib():
     def get_total_length(self):
         return torch.sum(self._motion_lengths).item()
 
-    def get_motion(self, motion_id):
-        return self._motions[motion_id]
-
     def sample_motions(self, n):
         motion_ids = torch.multinomial(self._motion_weights, num_samples=n, replacement=True)
         return motion_ids


### PR DESCRIPTION
Hi Jason,

Currently, there's no `self._motions` defined in `MotionLib`. So the function `def get_motion(self, motion_id)` will raise error.

I added the attribute and load them when loading the pkl files. With this, we can call `get_motion()` without errors. It'll return an `Motion` object.