### PR TITLE
[Bug Fix] view_motion env breaks when no key bodies are defined

### DIFF
--- a/mimickit/envs/view_motion_env.py
+++ b/mimickit/envs/view_motion_env.py
@@ -69,7 +69,9 @@ class ViewMotionEnv(char_env.CharEnv):
         body_pos, body_rot = self._kin_char_model.forward_kinematics(root_pos=root_pos,
                                                                      root_rot=root_rot,
                                                                      joint_rot=joint_rot)
-        self._ref_body_pos[:] = body_pos
+
+        if (self._has_key_bodies()):
+            self._ref_body_pos[:] = body_pos
 
         self._engine.set_body_pos(None, char_id, body_pos)
         self._engine.set_body_rot(None, char_id, body_rot)


### PR DESCRIPTION
Currently, the `view_motion` environment crashes if the config file doesn’t include any key bodies. When this happens, it throws the following error:
```
'ViewMotionEnv' object has no attribute '_ref_body_pos'
```

I fixed the problem by checking `self._has_key_bodies()` before updating `self._ref_body_pos`.