### PR TITLE
[Bug Fix] Newton engine MJCF model mass calculation inconsistency

### DIFF
--- a/mimickit/engines/newton_engine.py
+++ b/mimickit/engines/newton_engine.py
@@ -902,6 +902,7 @@ class NewtonEngine(engine.Engine):
                 obj_builder.add_mjcf(
                     asset_file,
                     floating=not fix_root,
+                    ignore_inertial_definitions=False,
                     collapse_fixed_joints=False,
                     enable_self_collisions=enable_self_collisions,
                     convert_3d_hinge_to_ball_joints=True
@@ -910,6 +911,7 @@ class NewtonEngine(engine.Engine):
                 obj_builder.add_urdf(
                     asset_file,
                     floating=not fix_root,
+                    ignore_inertial_definitions=False,
                     collapse_fixed_joints=False,
                     enable_self_collisions=enable_self_collisions,
                     joint_ordering="dfs"
@@ -952,7 +954,7 @@ class NewtonEngine(engine.Engine):
         return
 
     def _build_ground_contact_sensor(self):
-        self._ground_contact_sensor = newton.sensors.ContactSensor(self._sim_model,
+        self._ground_contact_sensor = newton.sensors.SensorContact(self._sim_model,
                                                                    sensing_obj_bodies="*",
                                                                    counterpart_shapes="ground*",
                                                                    include_total=True,

--- a/mimickit/envs/sim_env.py
+++ b/mimickit/envs/sim_env.py
@@ -207,7 +207,7 @@ class SimEnv(base_env.BaseEnv):
     
     def _build_camera(self, env_config):
         cam_pos = np.array([0.0, -5.0, 3.0])
-        cam_target = np.arrray([0.0, 0.0, 0.0])
+        cam_target = np.array([0.0, 0.0, 0.0])
         cam_mode = env_config.get("camera_mode", "still")
         cam_mode = camera.CameraMode[cam_mode]
 


### PR DESCRIPTION
## Problem

When testing `add_g1_env` with Newton engine, I found that `calc_obj_mass()` returns different mass values than those specified in the MJCF model files. This issue was identified through the following observations:

1. **Cross-engine comparison**: The character mass output from `isaac_gym_engine` and `newton_engine` were inconsistent for the same MJCF model
2. **MuJoCo validation**: When loading the same MJCF file with MuJoCo, the mass values matched the `<inertial mass>` definitions in the MJCF file, but `newton_engine` output did not align with these values

## Root Cause

Newton's `ModelBuilder.add_mjcf()` defaults to `ignore_inertial_definitions=True`, which:
- Ignores `<inertial mass>` definitions in MJCF files
- Recalculates body mass from collision geometry using `density × volume`
- Causes `calc_obj_mass()` (which sums `sim_model.body_mass`) to return values different from MJCF `<inertial mass>` definitions

**Note**: While Newton engine is under active development, even in the commit version specified in README.md (`cde9610aff71995d793f9b60e6dc26299e29885c`), the default value in [`builder.py` line 1350](https://github.com/newton-physics/newton/blob/cde9610aff71995d793f9b60e6dc26299e29885c/newton/_src/sim/builder.py) is `True`, so this fix is necessary for proper MJCF compatibility.

## Solution

- Set `ignore_inertial_definitions=False` in both `add_mjcf()` and `add_urdf()` calls to respect inertial mass definitions in model files
- This ensures `calc_obj_mass()` matches the mass values specified in MJCF/URDF files, making Newton engine behavior consistent with MuJoCo and other physics engines

## Additional Fixes

- **API update**: Changed `ContactSensor` → `SensorContact` to match the latest Newton version API
- **Typo fix**: Fixed `np.arrray` → `np.array` in `sim_env.py`

## Files Changed

- `mimickit/engines/newton_engine.py`: 
  - Added `ignore_inertial_definitions=False` parameter to `add_mjcf()` and `add_urdf()` calls
  - Updated `ContactSensor` → `SensorContact` API call
- `mimickit/envs/sim_env.py`: Fixed typo

## Testing

I have verified that on g1.xml model:
- `calc_obj_mass()` now returns values matching the `<inertial mass>` definitions in MJCF model files (e.g., `g1.xml`)
- Mass values are now consistent between `isaac_gym_engine` and `newton_engine` for the same models
- Mass values align with MuJoCo's interpretation of the same MJCF files