### PR TITLE
 [Bug Fix] Fix IsaacLab multi-GPU training data device mismatch

### DIFF
--- a/mimickit/engines/isaac_lab_engine.py
+++ b/mimickit/engines/isaac_lab_engine.py
@@ -653,7 +653,7 @@ class IsaacLabEngine(engine.Engine):
         return
     
     def _create_simulator(self, sim_timestep, visualize):
-        self._app_launcher = AppLauncher({"headless": not visualize})
+        self._app_launcher = AppLauncher({"headless": not visualize, "device": self._device})
 
         import isaaclab.sim as sim_utils
         from isaacsim.core.utils.stage import get_current_stage


### PR DESCRIPTION
Fixed the simulation device error that occurs during multi-GPU training when using IsaacLab as the engine

[issue link](https://github.com/xbpeng/MimicKit/issues/70)