### PR TITLE
fix: bare except → except ImportError in engine_builder

### DIFF
--- a/mimickit/engines/engine_builder.py
+++ b/mimickit/engines/engine_builder.py
@@ -1,6 +1,6 @@
 try:
     import isaacgym.gymapi as gymapi
-except:
+except ImportError:
     pass
 
 def build_engine(config, num_envs, device, visualize, record_video=False):


### PR DESCRIPTION
Replace bare `except:` with `except ImportError:` in isaacgym import fallback (`engine_builder.py:3`).