### PR TITLE
Log samples per second in base_agent.py

### DIFF
--- a/mimickit/learning/base_agent.py
+++ b/mimickit/learning/base_agent.py
@@ -353,7 +353,7 @@ class BaseAgent(torch.nn.Module):
         self._logger.log("Iteration", self._iter, collection="1_Info")
         self._logger.log("Wall_Time", wall_time, collection="1_Info")
         self._logger.log("Samples", self._sample_count, collection="1_Info")
-        self._logger.log("Samples_Per_Second", self._sample_count / (wall_time * (60 * 60)), collection="1_Info")
+        self._logger.log("Samples_Per_Second", self._sample_count / (wall_time * (60 * 60)), collection="1_Info", quiet=True)
 
         test_return = test_info["mean_return"]
         test_ep_len = test_info["mean_ep_len"]

--- a/mimickit/learning/base_agent.py
+++ b/mimickit/learning/base_agent.py
@@ -353,7 +353,7 @@ class BaseAgent(torch.nn.Module):
         self._logger.log("Iteration", self._iter, collection="1_Info")
         self._logger.log("Wall_Time", wall_time, collection="1_Info")
         self._logger.log("Samples", self._sample_count, collection="1_Info")
-        self._logger.log("Samples_Per_Second", self._sample_count / wall_time, collection="1_Info")
+        self._logger.log("Samples_Per_Second", self._sample_count / (wall_time * (60 * 60)), collection="1_Info")
 
         test_return = test_info["mean_return"]
         test_ep_len = test_info["mean_ep_len"]

--- a/mimickit/learning/base_agent.py
+++ b/mimickit/learning/base_agent.py
@@ -353,7 +353,8 @@ class BaseAgent(torch.nn.Module):
         self._logger.log("Iteration", self._iter, collection="1_Info")
         self._logger.log("Wall_Time", wall_time, collection="1_Info")
         self._logger.log("Samples", self._sample_count, collection="1_Info")
-        
+        self._logger.log("Samples_Per_Second", self._sample_count / wall_time, collection="1_Info")
+
         test_return = test_info["mean_return"]
         test_ep_len = test_info["mean_ep_len"]
         test_eps = test_info["num_eps"]


### PR DESCRIPTION
I’m proposing a small addition to _log_train_info to log samples per second.

I’ve found this metric useful as a quick way to monitor training throughput. It makes it easier to spot when a code change may need optimization, and to estimate how long a run will take to collect the same number of samples as another experiment.

New log train info output:

```sh
------------------------------------------
|            Iteration |             737 |
|            Wall_Time |           0.981 |
|              Samples |        48365568 |
|   Samples_Per_Second |        1.16e+04 |
|          Test_Return |             165 |
|         Train_Return |             174 |
|                 Loss |           0.214 |
|          Critic_Loss |           0.141 |
|           Actor_Loss |          0.0722 |
|            Clip_Frac |           0.697 |
|            Imp_Ratio |            0.99 |
|    Action_Bound_Loss |        4.77e-07 |
|             Adv_Mean |            0.38 |
|              Adv_Std |           0.341 |
|             Exp_Prob |               1 |
------------------------------------------
```