### PR TITLE
[FEATURE] Add Automatic Mixed Precision option

### DIFF
--- a/data/agents/add_g1_agent.yaml
+++ b/data/agents/add_g1_agent.yaml
@@ -13,15 +13,21 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    
+    use_amp: false
+    amp_type: "bf16"
+
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
+    use_amp: false
+    amp_type: "bf16"
 
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
+    use_amp: false
+    amp_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/add_g1_agent.yaml
+++ b/data/agents/add_g1_agent.yaml
@@ -13,27 +13,23 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
 
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
 
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 100
 test_episodes: 32
 normalizer_samples: 100000000
+
+use_mixed_precision: false
 
 actor_epochs: 5
 actor_batch_size: 4

--- a/data/agents/add_g1_agent.yaml
+++ b/data/agents/add_g1_agent.yaml
@@ -13,7 +13,7 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-
+    
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4

--- a/data/agents/add_g1_agent.yaml
+++ b/data/agents/add_g1_agent.yaml
@@ -13,21 +13,21 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/add_go2_agent.yaml
+++ b/data/agents/add_go2_agent.yaml
@@ -13,15 +13,21 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 2e-4
-    
+    use_amp: false
+    amp_type: "bf16"
+
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
+    use_amp: false
+    amp_type: "bf16"
 
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
+    use_amp: false
+    amp_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/add_go2_agent.yaml
+++ b/data/agents/add_go2_agent.yaml
@@ -13,21 +13,21 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 2e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/add_go2_agent.yaml
+++ b/data/agents/add_go2_agent.yaml
@@ -13,27 +13,23 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 2e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
 
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 100
 test_episodes: 32
 normalizer_samples: 100000000
+
+use_mixed_precision: false
 
 actor_epochs: 5
 actor_batch_size: 4

--- a/data/agents/add_go2_agent.yaml
+++ b/data/agents/add_go2_agent.yaml
@@ -22,7 +22,7 @@ disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
-    
+
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 100

--- a/data/agents/add_humanoid_agent.yaml
+++ b/data/agents/add_humanoid_agent.yaml
@@ -13,15 +13,21 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    
+    use_amp: false
+    amp_type: "bf16"
+
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
+    use_amp: false
+    amp_type: "bf16"
 
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
+    use_amp: false
+    amp_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/add_humanoid_agent.yaml
+++ b/data/agents/add_humanoid_agent.yaml
@@ -13,27 +13,23 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 100
 test_episodes: 32
 normalizer_samples: 100000000
+
+use_mixed_precision: false
 
 actor_epochs: 5
 actor_batch_size: 4

--- a/data/agents/add_humanoid_agent.yaml
+++ b/data/agents/add_humanoid_agent.yaml
@@ -13,21 +13,21 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/add_humanoid_agent.yaml
+++ b/data/agents/add_humanoid_agent.yaml
@@ -17,12 +17,12 @@ actor_optimizer:
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    
+
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
-    
+
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 100

--- a/data/agents/add_pi_plus_agent.yaml
+++ b/data/agents/add_pi_plus_agent.yaml
@@ -13,15 +13,21 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    
+    use_amp: false
+    amp_type: "bf16"
+
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
+    use_amp: false
+    amp_type: "bf16"
 
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
+    use_amp: false
+    amp_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/add_pi_plus_agent.yaml
+++ b/data/agents/add_pi_plus_agent.yaml
@@ -13,27 +13,23 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 100
 test_episodes: 32
 normalizer_samples: 100000000
+
+use_mixed_precision: false
 
 actor_epochs: 5
 actor_batch_size: 4

--- a/data/agents/add_pi_plus_agent.yaml
+++ b/data/agents/add_pi_plus_agent.yaml
@@ -13,21 +13,21 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/add_pi_plus_agent.yaml
+++ b/data/agents/add_pi_plus_agent.yaml
@@ -17,12 +17,12 @@ actor_optimizer:
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    
+
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
-    
+
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 100

--- a/data/agents/add_smpl_agent.yaml
+++ b/data/agents/add_smpl_agent.yaml
@@ -13,15 +13,21 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    
+    use_amp: false
+    amp_type: "bf16"
+
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
+    use_amp: false
+    amp_type: "bf16"
 
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
+    use_amp: false
+    amp_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/add_smpl_agent.yaml
+++ b/data/agents/add_smpl_agent.yaml
@@ -13,27 +13,23 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 100
 test_episodes: 32
 normalizer_samples: 100000000
+
+use_mixed_precision: false
 
 actor_epochs: 5
 actor_batch_size: 4

--- a/data/agents/add_smpl_agent.yaml
+++ b/data/agents/add_smpl_agent.yaml
@@ -13,21 +13,21 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/add_smpl_agent.yaml
+++ b/data/agents/add_smpl_agent.yaml
@@ -17,12 +17,12 @@ actor_optimizer:
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    
+
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
-    
+
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 100

--- a/data/agents/amp_g1_agent.yaml
+++ b/data/agents/amp_g1_agent.yaml
@@ -13,15 +13,21 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    
+    use_amp: false
+    amp_type: "bf16"
+
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
+    use_amp: false
+    amp_type: "bf16"
 
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
+    use_amp: false
+    amp_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/amp_g1_agent.yaml
+++ b/data/agents/amp_g1_agent.yaml
@@ -13,27 +13,23 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 100
 test_episodes: 32
 normalizer_samples: 100000000
+
+use_mixed_precision: false
 
 actor_epochs: 5
 actor_batch_size: 4

--- a/data/agents/amp_g1_agent.yaml
+++ b/data/agents/amp_g1_agent.yaml
@@ -13,21 +13,21 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/amp_g1_agent.yaml
+++ b/data/agents/amp_g1_agent.yaml
@@ -17,12 +17,12 @@ actor_optimizer:
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    
+
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
-    
+
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 100

--- a/data/agents/amp_go2_agent.yaml
+++ b/data/agents/amp_go2_agent.yaml
@@ -13,15 +13,21 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 2e-4
-    
+    use_amp: false
+    amp_type: "bf16"
+
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
+    use_amp: false
+    amp_type: "bf16"
 
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
+    use_amp: false
+    amp_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/amp_go2_agent.yaml
+++ b/data/agents/amp_go2_agent.yaml
@@ -13,21 +13,21 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 2e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/amp_go2_agent.yaml
+++ b/data/agents/amp_go2_agent.yaml
@@ -13,27 +13,23 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 2e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 100
 test_episodes: 32
 normalizer_samples: 100000000
+
+use_mixed_precision: false
 
 actor_epochs: 5
 actor_batch_size: 4

--- a/data/agents/amp_go2_agent.yaml
+++ b/data/agents/amp_go2_agent.yaml
@@ -17,12 +17,12 @@ actor_optimizer:
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    
+
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
-    
+
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 100

--- a/data/agents/amp_humanoid_agent.yaml
+++ b/data/agents/amp_humanoid_agent.yaml
@@ -13,15 +13,21 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    
+    use_amp: false
+    amp_type: "bf16"
+
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
+    use_amp: false
+    amp_type: "bf16"
 
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
+    use_amp: false
+    amp_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/amp_humanoid_agent.yaml
+++ b/data/agents/amp_humanoid_agent.yaml
@@ -13,27 +13,23 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 100
 test_episodes: 32
 normalizer_samples: 100000000
+
+use_mixed_precision: false
 
 actor_epochs: 5
 actor_batch_size: 4

--- a/data/agents/amp_humanoid_agent.yaml
+++ b/data/agents/amp_humanoid_agent.yaml
@@ -13,21 +13,21 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/amp_humanoid_agent.yaml
+++ b/data/agents/amp_humanoid_agent.yaml
@@ -17,12 +17,12 @@ actor_optimizer:
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    
+
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
-    
+
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 100

--- a/data/agents/amp_pi_plus_agent.yaml
+++ b/data/agents/amp_pi_plus_agent.yaml
@@ -13,15 +13,21 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    
+    use_amp: false
+    amp_type: "bf16"
+
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
+    use_amp: false
+    amp_type: "bf16"
 
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
+    use_amp: false
+    amp_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/amp_pi_plus_agent.yaml
+++ b/data/agents/amp_pi_plus_agent.yaml
@@ -13,27 +13,23 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 100
 test_episodes: 32
 normalizer_samples: 100000000
+
+use_mixed_precision: false
 
 actor_epochs: 5
 actor_batch_size: 4

--- a/data/agents/amp_pi_plus_agent.yaml
+++ b/data/agents/amp_pi_plus_agent.yaml
@@ -13,21 +13,21 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/amp_pi_plus_agent.yaml
+++ b/data/agents/amp_pi_plus_agent.yaml
@@ -17,12 +17,12 @@ actor_optimizer:
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    
+
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
-    
+
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 100

--- a/data/agents/amp_smpl_agent.yaml
+++ b/data/agents/amp_smpl_agent.yaml
@@ -13,15 +13,21 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    
+    use_amp: false
+    amp_type: "bf16"
+
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
+    use_amp: false
+    amp_type: "bf16"
 
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
+    use_amp: false
+    amp_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/amp_smpl_agent.yaml
+++ b/data/agents/amp_smpl_agent.yaml
@@ -13,27 +13,23 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 100
 test_episodes: 32
 normalizer_samples: 100000000
+
+use_mixed_precision: false
 
 actor_epochs: 5
 actor_batch_size: 4

--- a/data/agents/amp_smpl_agent.yaml
+++ b/data/agents/amp_smpl_agent.yaml
@@ -13,21 +13,21 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/amp_smpl_agent.yaml
+++ b/data/agents/amp_smpl_agent.yaml
@@ -17,12 +17,12 @@ actor_optimizer:
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    
+
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
-    
+
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 100

--- a/data/agents/amp_task_humanoid_agent.yaml
+++ b/data/agents/amp_task_humanoid_agent.yaml
@@ -13,15 +13,21 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 5e-5
-    
+    use_amp: false
+    amp_type: "bf16"
+
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
+    use_amp: false
+    amp_type: "bf16"
 
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
+    use_amp: false
+    amp_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/amp_task_humanoid_agent.yaml
+++ b/data/agents/amp_task_humanoid_agent.yaml
@@ -13,21 +13,21 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 5e-5
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/amp_task_humanoid_agent.yaml
+++ b/data/agents/amp_task_humanoid_agent.yaml
@@ -13,27 +13,23 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 5e-5
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 200
 test_episodes: 32
 normalizer_samples: 100000000
+
+use_mixed_precision: false
 
 actor_epochs: 5
 actor_batch_size: 4

--- a/data/agents/amp_task_humanoid_agent.yaml
+++ b/data/agents/amp_task_humanoid_agent.yaml
@@ -17,12 +17,12 @@ actor_optimizer:
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    
+
 disc_optimizer:
     type: "SGD"
     learning_rate: 2.5e-4
     weight_decay: 0.0001
-    
+
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 200

--- a/data/agents/ase_humanoid_agent.yaml
+++ b/data/agents/ase_humanoid_agent.yaml
@@ -16,19 +16,27 @@ model:
 actor_optimizer:
     type: "Adam"
     learning_rate: 2e-5
-    
+    use_amp: false
+    amp_type: "bf16"
+
 critic_optimizer:
     type: "Adam"
     learning_rate: 5e-5
-    
+    use_amp: false
+    amp_type: "bf16"
+
 disc_optimizer:
     type: "Adam"
     learning_rate: 5e-5
     weight_decay: 0.0001
-    
+    use_amp: false
+    amp_type: "bf16"
+
 enc_optimizer:
     type: "Adam"
     learning_rate: 5e-5
+    use_amp: false
+    amp_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/ase_humanoid_agent.yaml
+++ b/data/agents/ase_humanoid_agent.yaml
@@ -29,7 +29,7 @@ disc_optimizer:
 enc_optimizer:
     type: "Adam"
     learning_rate: 5e-5
-    
+
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 200

--- a/data/agents/ase_humanoid_agent.yaml
+++ b/data/agents/ase_humanoid_agent.yaml
@@ -16,27 +16,27 @@ model:
 actor_optimizer:
     type: "Adam"
     learning_rate: 2e-5
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 critic_optimizer:
     type: "Adam"
     learning_rate: 5e-5
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 disc_optimizer:
     type: "Adam"
     learning_rate: 5e-5
     weight_decay: 0.0001
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 enc_optimizer:
     type: "Adam"
     learning_rate: 5e-5
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/ase_humanoid_agent.yaml
+++ b/data/agents/ase_humanoid_agent.yaml
@@ -16,33 +16,27 @@ model:
 actor_optimizer:
     type: "Adam"
     learning_rate: 2e-5
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 critic_optimizer:
     type: "Adam"
     learning_rate: 5e-5
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 disc_optimizer:
     type: "Adam"
     learning_rate: 5e-5
     weight_decay: 0.0001
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 enc_optimizer:
     type: "Adam"
     learning_rate: 5e-5
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 200
 test_episodes: 32
 normalizer_samples: 500000000
+
+use_mixed_precision: false
 
 actor_epochs: 5
 actor_batch_size: 4

--- a/data/agents/deepmimic_g1_ppo_agent.yaml
+++ b/data/agents/deepmimic_g1_ppo_agent.yaml
@@ -11,10 +11,14 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    
+    use_amp: false
+    amp_type: "bf16"
+
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
+    use_amp: false
+    amp_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/deepmimic_g1_ppo_agent.yaml
+++ b/data/agents/deepmimic_g1_ppo_agent.yaml
@@ -15,7 +15,7 @@ actor_optimizer:
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    
+
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 100

--- a/data/agents/deepmimic_g1_ppo_agent.yaml
+++ b/data/agents/deepmimic_g1_ppo_agent.yaml
@@ -11,14 +11,14 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/deepmimic_g1_ppo_agent.yaml
+++ b/data/agents/deepmimic_g1_ppo_agent.yaml
@@ -11,20 +11,18 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 100
 test_episodes: 32
 normalizer_samples: 100000000
+
+use_mixed_precision: false
 
 actor_epochs: 5
 actor_batch_size: 4

--- a/data/agents/deepmimic_go2_ppo_agent.yaml
+++ b/data/agents/deepmimic_go2_ppo_agent.yaml
@@ -11,10 +11,14 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 2e-4
-    
+    use_amp: false
+    amp_type: "bf16"
+
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
+    use_amp: false
+    amp_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/deepmimic_go2_ppo_agent.yaml
+++ b/data/agents/deepmimic_go2_ppo_agent.yaml
@@ -11,14 +11,14 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 2e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/deepmimic_go2_ppo_agent.yaml
+++ b/data/agents/deepmimic_go2_ppo_agent.yaml
@@ -15,7 +15,7 @@ actor_optimizer:
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    
+
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 100

--- a/data/agents/deepmimic_go2_ppo_agent.yaml
+++ b/data/agents/deepmimic_go2_ppo_agent.yaml
@@ -11,20 +11,18 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 2e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 100
 test_episodes: 32
 normalizer_samples: 100000000
+
+use_mixed_precision: false
 
 actor_epochs: 5
 actor_batch_size: 4

--- a/data/agents/deepmimic_humanoid_awr_agent.yaml
+++ b/data/agents/deepmimic_humanoid_awr_agent.yaml
@@ -11,10 +11,14 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    
+    use_amp: false
+    amp_type: "bf16"
+
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
+    use_amp: false
+    amp_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/deepmimic_humanoid_awr_agent.yaml
+++ b/data/agents/deepmimic_humanoid_awr_agent.yaml
@@ -15,7 +15,7 @@ actor_optimizer:
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    
+
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 100

--- a/data/agents/deepmimic_humanoid_awr_agent.yaml
+++ b/data/agents/deepmimic_humanoid_awr_agent.yaml
@@ -11,14 +11,14 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/deepmimic_humanoid_awr_agent.yaml
+++ b/data/agents/deepmimic_humanoid_awr_agent.yaml
@@ -11,20 +11,18 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 100
 test_episodes: 32
 normalizer_samples: 100000000
+
+use_mixed_precision: false
 
 actor_epochs: 5
 actor_batch_size: 4

--- a/data/agents/deepmimic_humanoid_ppo_agent.yaml
+++ b/data/agents/deepmimic_humanoid_ppo_agent.yaml
@@ -11,10 +11,14 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    
+    use_amp: false
+    amp_type: "bf16"
+
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
+    use_amp: false
+    amp_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/deepmimic_humanoid_ppo_agent.yaml
+++ b/data/agents/deepmimic_humanoid_ppo_agent.yaml
@@ -11,14 +11,14 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: true
+    mixed_precision_type: "bf16"
 
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: true
+    mixed_precision_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/deepmimic_humanoid_ppo_agent.yaml
+++ b/data/agents/deepmimic_humanoid_ppo_agent.yaml
@@ -11,20 +11,18 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: true
-    mixed_precision_type: "bf16"
-
+    
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: true
-    mixed_precision_type: "bf16"
-
+    
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 100
 test_episodes: 32
 normalizer_samples: 100000000
+
+use_mixed_precision: false
 
 actor_epochs: 5
 actor_batch_size: 4

--- a/data/agents/deepmimic_humanoid_ppo_agent.yaml
+++ b/data/agents/deepmimic_humanoid_ppo_agent.yaml
@@ -15,7 +15,7 @@ actor_optimizer:
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    
+
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 100

--- a/data/agents/deepmimic_pi_plus_ppo_agent.yaml
+++ b/data/agents/deepmimic_pi_plus_ppo_agent.yaml
@@ -11,10 +11,14 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    
+    use_amp: false
+    amp_type: "bf16"
+
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
+    use_amp: false
+    amp_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/deepmimic_pi_plus_ppo_agent.yaml
+++ b/data/agents/deepmimic_pi_plus_ppo_agent.yaml
@@ -15,7 +15,7 @@ actor_optimizer:
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    
+
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 100

--- a/data/agents/deepmimic_pi_plus_ppo_agent.yaml
+++ b/data/agents/deepmimic_pi_plus_ppo_agent.yaml
@@ -11,14 +11,14 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/deepmimic_pi_plus_ppo_agent.yaml
+++ b/data/agents/deepmimic_pi_plus_ppo_agent.yaml
@@ -11,20 +11,18 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 100
 test_episodes: 32
 normalizer_samples: 100000000
+
+use_mixed_precision: false
 
 actor_epochs: 5
 actor_batch_size: 4

--- a/data/agents/deepmimic_smpl_ppo_agent.yaml
+++ b/data/agents/deepmimic_smpl_ppo_agent.yaml
@@ -11,10 +11,14 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    
+    use_amp: false
+    amp_type: "bf16"
+
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
+    use_amp: false
+    amp_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/deepmimic_smpl_ppo_agent.yaml
+++ b/data/agents/deepmimic_smpl_ppo_agent.yaml
@@ -15,7 +15,7 @@ actor_optimizer:
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    
+
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 100

--- a/data/agents/deepmimic_smpl_ppo_agent.yaml
+++ b/data/agents/deepmimic_smpl_ppo_agent.yaml
@@ -11,14 +11,14 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/deepmimic_smpl_ppo_agent.yaml
+++ b/data/agents/deepmimic_smpl_ppo_agent.yaml
@@ -11,20 +11,18 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 100
 test_episodes: 32
 normalizer_samples: 100000000
+
+use_mixed_precision: false
 
 actor_epochs: 5
 actor_batch_size: 4

--- a/data/agents/lcp_g1_agent.yaml
+++ b/data/agents/lcp_g1_agent.yaml
@@ -11,10 +11,14 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    
+    use_amp: false
+    amp_type: "bf16"
+
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
+    use_amp: false
+    amp_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/lcp_g1_agent.yaml
+++ b/data/agents/lcp_g1_agent.yaml
@@ -15,7 +15,7 @@ actor_optimizer:
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    
+
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 100

--- a/data/agents/lcp_g1_agent.yaml
+++ b/data/agents/lcp_g1_agent.yaml
@@ -11,14 +11,14 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/lcp_g1_agent.yaml
+++ b/data/agents/lcp_g1_agent.yaml
@@ -11,20 +11,18 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 100
 test_episodes: 32
 normalizer_samples: 100000000
+
+use_mixed_precision: false
 
 actor_epochs: 5
 actor_batch_size: 4

--- a/data/agents/smp_humanoid_agent.yaml
+++ b/data/agents/smp_humanoid_agent.yaml
@@ -11,10 +11,14 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    
+    use_amp: false
+    amp_type: "bf16"
+
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
+    use_amp: false
+    amp_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/smp_humanoid_agent.yaml
+++ b/data/agents/smp_humanoid_agent.yaml
@@ -15,7 +15,7 @@ actor_optimizer:
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    
+
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 100

--- a/data/agents/smp_humanoid_agent.yaml
+++ b/data/agents/smp_humanoid_agent.yaml
@@ -11,14 +11,14 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/smp_humanoid_agent.yaml
+++ b/data/agents/smp_humanoid_agent.yaml
@@ -11,20 +11,18 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 100
 test_episodes: 32
 normalizer_samples: 100000000
+
+use_mixed_precision: false
 
 actor_epochs: 5
 actor_batch_size: 4

--- a/data/agents/smp_task_humanoid_agent.yaml
+++ b/data/agents/smp_task_humanoid_agent.yaml
@@ -11,10 +11,14 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    
+    use_amp: false
+    amp_type: "bf16"
+
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
+    use_amp: false
+    amp_type: "bf16"
 
 
 discount: 0.99

--- a/data/agents/smp_task_humanoid_agent.yaml
+++ b/data/agents/smp_task_humanoid_agent.yaml
@@ -15,7 +15,7 @@ actor_optimizer:
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    
+
 
 discount: 0.99
 steps_per_iter: 32

--- a/data/agents/smp_task_humanoid_agent.yaml
+++ b/data/agents/smp_task_humanoid_agent.yaml
@@ -11,14 +11,14 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_amp: false
-    amp_type: "bf16"
+    use_mixed_precision: false
+    mixed_precision_type: "bf16"
 
 
 discount: 0.99

--- a/data/agents/smp_task_humanoid_agent.yaml
+++ b/data/agents/smp_task_humanoid_agent.yaml
@@ -11,21 +11,19 @@ model:
 actor_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 critic_optimizer:
     type: "SGD"
     learning_rate: 1e-4
-    use_mixed_precision: false
-    mixed_precision_type: "bf16"
-
+    
 
 discount: 0.99
 steps_per_iter: 32
 iters_per_output: 200
 test_episodes: 32
 normalizer_samples: 100000000
+
+use_mixed_precision: false
 
 actor_epochs: 5
 actor_batch_size: 4

--- a/mimickit/learning/amp_agent.py
+++ b/mimickit/learning/amp_agent.py
@@ -150,8 +150,9 @@ class AMPAgent(ppo_agent.PPOAgent):
 
         for i in range(steps):
             batch = self._exp_buffer.sample(batch_size)
-            loss_info = self._compute_disc_loss(batch)
-            loss = loss_info["disc_loss"]
+            with torch.amp.autocast(device_type="cuda", enabled=self._use_mixed_precision, dtype=torch.bfloat16):
+                loss_info = self._compute_disc_loss(batch)
+                loss = loss_info["disc_loss"]
             self._disc_optimizer.step(loss)
 
             torch_util.add_torch_dict(loss_info, info)

--- a/mimickit/learning/ase_agent.py
+++ b/mimickit/learning/ase_agent.py
@@ -255,8 +255,9 @@ class ASEAgent(amp_agent.AMPAgent):
 
         for i in range(steps):
             batch = self._exp_buffer.sample(batch_size)
-            loss_info = self._compute_enc_loss(batch)
-            loss = loss_info["enc_loss"]
+            with torch.amp.autocast(device_type="cuda", enabled=self._use_mixed_precision, dtype=torch.bfloat16):
+                loss_info = self._compute_enc_loss(batch)
+                loss = loss_info["enc_loss"]
             self._enc_optimizer.step(loss)
 
             torch_util.add_torch_dict(loss_info, info)

--- a/mimickit/learning/awr_agent.py
+++ b/mimickit/learning/awr_agent.py
@@ -189,9 +189,12 @@ class AWRAgent(base_agent.BaseAgent):
 
         for i in range(steps):
             batch = self._exp_buffer.sample(batch_size)
-            loss_info = self._compute_critic_loss(batch)
-            loss = loss_info["critic_loss"]
-            self._critic_optimizer.step(loss)
+            loss_info = None
+            def loss_factory():
+                nonlocal loss_info
+                loss_info = self._compute_critic_loss(batch)
+                return loss_info["critic_loss"]
+            self._critic_optimizer.step(loss_factory)
 
             torch_util.add_torch_dict(loss_info, info)
         
@@ -203,9 +206,12 @@ class AWRAgent(base_agent.BaseAgent):
 
         for i in range(num_steps):
             batch = self._exp_buffer.sample(batch_size)
-            loss_info = self._compute_actor_loss(batch)
-            loss = loss_info["actor_loss"]
-            self._actor_optimizer.step(loss)
+            loss_info = None
+            def loss_factory():
+                nonlocal loss_info
+                loss_info = self._compute_actor_loss(batch)
+                return loss_info["actor_loss"]
+            self._actor_optimizer.step(loss_factory)
 
             torch_util.add_torch_dict(loss_info, info)
         

--- a/mimickit/learning/awr_agent.py
+++ b/mimickit/learning/awr_agent.py
@@ -189,12 +189,10 @@ class AWRAgent(base_agent.BaseAgent):
 
         for i in range(steps):
             batch = self._exp_buffer.sample(batch_size)
-            loss_info = None
-            def loss_factory():
-                nonlocal loss_info
+            with torch.amp.autocast(device_type="cuda", enabled=self._use_mixed_precision, dtype=torch.bfloat16):
                 loss_info = self._compute_critic_loss(batch)
-                return loss_info["critic_loss"]
-            self._critic_optimizer.step(loss_factory)
+                loss = loss_info["critic_loss"]
+            self._critic_optimizer.step(loss)
 
             torch_util.add_torch_dict(loss_info, info)
         
@@ -206,12 +204,10 @@ class AWRAgent(base_agent.BaseAgent):
 
         for i in range(num_steps):
             batch = self._exp_buffer.sample(batch_size)
-            loss_info = None
-            def loss_factory():
-                nonlocal loss_info
+            with torch.amp.autocast(device_type="cuda", enabled=self._use_mixed_precision, dtype=torch.bfloat16):
                 loss_info = self._compute_actor_loss(batch)
-                return loss_info["actor_loss"]
-            self._actor_optimizer.step(loss_factory)
+                loss = loss_info["actor_loss"]
+            self._actor_optimizer.step(loss)
 
             torch_util.add_torch_dict(loss_info, info)
         

--- a/mimickit/learning/base_agent.py
+++ b/mimickit/learning/base_agent.py
@@ -151,6 +151,8 @@ class BaseAgent(torch.nn.Module):
         self._test_episodes = config["test_episodes"]
         
         self._steps_per_iter = config["steps_per_iter"]
+        
+        self._use_mixed_precision = config["use_mixed_precision"]
         return
 
     def _build_normalizers(self):

--- a/mimickit/learning/mp_optimizer.py
+++ b/mimickit/learning/mp_optimizer.py
@@ -1,6 +1,12 @@
+import typing as tp
+
 import torch
 
 import util.mp_util as mp_util
+
+
+LossFactory = tp.Callable[[], torch.Tensor]
+
 
 class MPOptimizer():
     CHECK_SYNC_STEPS = 1000
@@ -9,6 +15,12 @@ class MPOptimizer():
         self._param_list = param_list
         self._grad_clip = float(config.get("grad_clip", 0.0))
         self._optimizer = self._build_optimizer(config, param_list)
+        self._use_amp = bool(config.get("use_amp", False))
+        self._amp_dtype = self._parse_amp_dtype(config.get("amp_type", "fp16"))
+
+        use_grad_scaler = self._use_amp and self._amp_dtype == torch.float16
+        self._grad_scaler = torch.cuda.amp.GradScaler(enabled=use_grad_scaler)
+
         self._steps = 0
         
         if (mp_util.enable_mp()):
@@ -17,9 +29,25 @@ class MPOptimizer():
         self.sync()
         return
     
-    def step(self, loss):
+    def step(self, loss_or_factory: torch.Tensor | LossFactory) -> torch.Tensor:
         self._optimizer.zero_grad()
-        loss.backward()
+
+        if callable(loss_or_factory):
+            with torch.cuda.amp.autocast(
+                enabled=self._use_amp,
+                dtype=self._amp_dtype,
+            ):
+                loss = loss_or_factory()
+        else:
+            loss = loss_or_factory
+
+        loss = loss.float()
+
+        if (self._grad_scaler.is_enabled()):
+            self._grad_scaler.scale(loss).backward()
+            self._grad_scaler.unscale_(self._optimizer)
+        else:
+            loss.backward()
         
         if (mp_util.enable_mp()):
             self._aggregate_mp_grads()
@@ -27,7 +55,11 @@ class MPOptimizer():
         if (self._enable_grad_clip()):
             self._clip_grads(self._grad_clip)
 
-        self._optimizer.step()
+        if (self._grad_scaler.is_enabled()):
+            self._grad_scaler.step(self._optimizer)
+            self._grad_scaler.update()
+        else:
+            self._optimizer.step()
         
         if (mp_util.enable_mp() and (self.get_steps() % self.CHECK_SYNC_STEPS == 0)):
             assert(self._check_synced()), "Network parameters desynchronized"
@@ -45,6 +77,14 @@ class MPOptimizer():
                 param.copy_(global_param)
         return
 
+    def _parse_amp_dtype(self, amp_type):
+        if (amp_type == "fp16"):
+            return torch.float16
+        elif (amp_type == "bf16"):
+            return torch.bfloat16
+        else:
+            assert(False), "Unsupported AMP type: " + amp_type
+    
     def _build_optimizer(self, config, param_list):
         lr = float(config["learning_rate"])
         weight_decay = float(config.get("weight_decay", 0.0))

--- a/mimickit/learning/mp_optimizer.py
+++ b/mimickit/learning/mp_optimizer.py
@@ -15,10 +15,10 @@ class MPOptimizer():
         self._param_list = param_list
         self._grad_clip = float(config.get("grad_clip", 0.0))
         self._optimizer = self._build_optimizer(config, param_list)
-        self._use_amp = bool(config.get("use_amp", False))
-        self._amp_dtype = self._parse_amp_dtype(config.get("amp_type", "fp16"))
+        self._use_mixed_precision = bool(config.get("use_mixed_precision", False))
+        self._amp_dtype = self._parse_amp_dtype(config.get("mixed_precision_type", "fp16"))
 
-        use_grad_scaler = self._use_amp and self._amp_dtype == torch.float16
+        use_grad_scaler = self._use_mixed_precision and self._amp_dtype == torch.float16
         self._grad_scaler = torch.cuda.amp.GradScaler(enabled=use_grad_scaler)
 
         self._steps = 0
@@ -33,8 +33,8 @@ class MPOptimizer():
         self._optimizer.zero_grad()
 
         if callable(loss_or_factory):
-            with torch.cuda.amp.autocast(
-                enabled=self._use_amp,
+            with torch.amp.autocast(
+                enabled=self._use_mixed_precision,
                 dtype=self._amp_dtype,
             ):
                 loss = loss_or_factory()
@@ -77,13 +77,13 @@ class MPOptimizer():
                 param.copy_(global_param)
         return
 
-    def _parse_amp_dtype(self, amp_type):
-        if (amp_type == "fp16"):
+    def _parse_amp_dtype(self, mixed_precision_type):
+        if (mixed_precision_type == "fp16"):
             return torch.float16
-        elif (amp_type == "bf16"):
+        elif (mixed_precision_type == "bf16"):
             return torch.bfloat16
         else:
-            assert(False), "Unsupported AMP type: " + amp_type
+            assert(False), "Unsupported AMP type: " + mixed_precision_type
     
     def _build_optimizer(self, config, param_list):
         lr = float(config["learning_rate"])

--- a/mimickit/learning/mp_optimizer.py
+++ b/mimickit/learning/mp_optimizer.py
@@ -1,12 +1,6 @@
-import typing as tp
-
 import torch
 
 import util.mp_util as mp_util
-
-
-LossFactory = tp.Callable[[], torch.Tensor]
-
 
 class MPOptimizer():
     CHECK_SYNC_STEPS = 1000
@@ -15,12 +9,6 @@ class MPOptimizer():
         self._param_list = param_list
         self._grad_clip = float(config.get("grad_clip", 0.0))
         self._optimizer = self._build_optimizer(config, param_list)
-        self._use_mixed_precision = bool(config.get("use_mixed_precision", False))
-        self._amp_dtype = self._parse_amp_dtype(config.get("mixed_precision_type", "fp16"))
-
-        use_grad_scaler = self._use_mixed_precision and self._amp_dtype == torch.float16
-        self._grad_scaler = torch.cuda.amp.GradScaler(enabled=use_grad_scaler)
-
         self._steps = 0
         
         if (mp_util.enable_mp()):
@@ -29,25 +17,9 @@ class MPOptimizer():
         self.sync()
         return
     
-    def step(self, loss_or_factory: torch.Tensor | LossFactory) -> torch.Tensor:
+    def step(self, loss):
         self._optimizer.zero_grad()
-
-        if callable(loss_or_factory):
-            with torch.amp.autocast(
-                enabled=self._use_mixed_precision,
-                dtype=self._amp_dtype,
-            ):
-                loss = loss_or_factory()
-        else:
-            loss = loss_or_factory
-
-        loss = loss.float()
-
-        if (self._grad_scaler.is_enabled()):
-            self._grad_scaler.scale(loss).backward()
-            self._grad_scaler.unscale_(self._optimizer)
-        else:
-            loss.backward()
+        loss.backward()
         
         if (mp_util.enable_mp()):
             self._aggregate_mp_grads()
@@ -55,11 +27,7 @@ class MPOptimizer():
         if (self._enable_grad_clip()):
             self._clip_grads(self._grad_clip)
 
-        if (self._grad_scaler.is_enabled()):
-            self._grad_scaler.step(self._optimizer)
-            self._grad_scaler.update()
-        else:
-            self._optimizer.step()
+        self._optimizer.step()
         
         if (mp_util.enable_mp() and (self.get_steps() % self.CHECK_SYNC_STEPS == 0)):
             assert(self._check_synced()), "Network parameters desynchronized"
@@ -77,14 +45,6 @@ class MPOptimizer():
                 param.copy_(global_param)
         return
 
-    def _parse_amp_dtype(self, mixed_precision_type):
-        if (mixed_precision_type == "fp16"):
-            return torch.float16
-        elif (mixed_precision_type == "bf16"):
-            return torch.bfloat16
-        else:
-            assert(False), "Unsupported AMP type: " + mixed_precision_type
-    
     def _build_optimizer(self, config, param_list):
         lr = float(config["learning_rate"])
         weight_decay = float(config.get("weight_decay", 0.0))

--- a/mimickit/learning/ppo_agent.py
+++ b/mimickit/learning/ppo_agent.py
@@ -186,9 +186,12 @@ class PPOAgent(base_agent.BaseAgent):
 
         for i in range(steps):
             batch = self._exp_buffer.sample(batch_size)
-            loss_info = self._compute_critic_loss(batch)
-            loss = loss_info["critic_loss"]
-            self._critic_optimizer.step(loss)
+            loss_info = None
+            def loss_factory():
+                nonlocal loss_info
+                loss_info = self._compute_critic_loss(batch)
+                return loss_info["critic_loss"]
+            self._critic_optimizer.step(loss_factory)
 
             torch_util.add_torch_dict(loss_info, info)
         
@@ -200,9 +203,12 @@ class PPOAgent(base_agent.BaseAgent):
 
         for i in range(num_steps):
             batch = self._exp_buffer.sample(batch_size)
-            loss_info = self._compute_actor_loss(batch)
-            loss = loss_info["actor_loss"]
-            self._actor_optimizer.step(loss)
+            loss_info = None
+            def loss_factory():
+                nonlocal loss_info
+                loss_info = self._compute_actor_loss(batch)
+                return loss_info["actor_loss"]
+            self._actor_optimizer.step(loss_factory)
 
             torch_util.add_torch_dict(loss_info, info)
         

--- a/mimickit/learning/ppo_agent.py
+++ b/mimickit/learning/ppo_agent.py
@@ -186,12 +186,10 @@ class PPOAgent(base_agent.BaseAgent):
 
         for i in range(steps):
             batch = self._exp_buffer.sample(batch_size)
-            loss_info = None
-            def loss_factory():
-                nonlocal loss_info
+            with torch.amp.autocast(device_type="cuda", enabled=self._use_mixed_precision, dtype=torch.bfloat16):
                 loss_info = self._compute_critic_loss(batch)
-                return loss_info["critic_loss"]
-            self._critic_optimizer.step(loss_factory)
+                loss = loss_info["critic_loss"]
+            self._critic_optimizer.step(loss)
 
             torch_util.add_torch_dict(loss_info, info)
         
@@ -203,12 +201,10 @@ class PPOAgent(base_agent.BaseAgent):
 
         for i in range(num_steps):
             batch = self._exp_buffer.sample(batch_size)
-            loss_info = None
-            def loss_factory():
-                nonlocal loss_info
+            with torch.amp.autocast(device_type="cuda", enabled=self._use_mixed_precision, dtype=torch.bfloat16):
                 loss_info = self._compute_actor_loss(batch)
-                return loss_info["actor_loss"]
-            self._actor_optimizer.step(loss_factory)
+                loss = loss_info["actor_loss"]
+            self._actor_optimizer.step(loss)
 
             torch_util.add_torch_dict(loss_info, info)
         


### PR DESCRIPTION
## Proposal 
I'm proposing adding an option to enable Automatic Mixed Precision (AMP) in order to improve training throughput with minimal code changes.

## Results
To validate the implementation, I benchmarked training before and after enabling AMP with:

```sh
python mimickit/run.py \
  --mode train \
  --num_envs 2048 \
  --engine_config data/engines/isaac_lab_engine.yaml \
  --env_config data/envs/deepmimic_humanoid_env.yaml \
  --agent_config data/agents/deepmimic_humanoid_ppo_agent.yaml \
  --visualize false
 ```
 
 The only configuration change was enabling in the current branch:
```yaml
     use_mixed_precision: True
```

Using the additional logging introduced in https://github.com/xbpeng/MimicKit/pull/107, I obtained the following results on an NVIDIA GeForce RTX 5070 Ti Laptop GPU.

 
Before Automatic Mixed Precision:
```sh
|   Samples_Per_Second |        3.89e+04 |
```

After Automatic Mixed Precision:
```sh
|   Samples_Per_Second |        6.86e+04 |
```

This corresponds to +70% increase in training throughput.

## Changes done:

- [x] Update `MPOptimizer` to support Automatic Mixed Precision (AMP) with both `"fp16"` and `"bf16"` modes
- [x] Update the agent `_update_actor` and `_update_critic` methods to pass a `loss_factory` to `optimizer.step`, allowing the forward pass and loss computation to run under AMP autocast
- [x] Update the configs while keeping the default behavior unchanged